### PR TITLE
Add flags used by librime

### DIFF
--- a/miniglog/logging.cc
+++ b/miniglog/logging.cc
@@ -30,6 +30,15 @@
 
 #include "./logging.h"
 
+namespace fLS {
+
+std::string FLAGS_log_dir_buf("");
+std::string& FLAGS_log_dir = FLAGS_log_dir_buf;
+
+}
+int32_t fLI::FLAGS_logfile_mode;
+int32_t fLI::FLAGS_minloglevel;
+
 namespace google {
 
 // This is the set of log sinks. This must be in a separate library to ensure

--- a/miniglog/logging.h
+++ b/miniglog/logging.h
@@ -113,6 +113,24 @@ const int INFO    =  0;
 
 // ------------------------- Glog compatibility ------------------------------
 
+namespace fLS {
+
+// Ignored, log level is always INFO
+extern std::string& FLAGS_log_dir;
+
+}
+using namespace fLS;
+
+namespace fLI {
+
+// Ignored
+extern int32_t FLAGS_logfile_mode;
+// Ignored
+extern int32_t FLAGS_minloglevel;
+
+}
+using namespace fLI;
+
 namespace google {
 
 typedef int LogSeverity;


### PR DESCRIPTION
Just a workaround, upgrade miniglog to glog 0.4 is too complicated